### PR TITLE
chore(hetzner-dns): fix typos in variables

### DIFF
--- a/hetzner-dns/data.tf
+++ b/hetzner-dns/data.tf
@@ -5,10 +5,10 @@
 
 locals {
   declared_dns_zone_names = toset([for record in var.hcloud_dns_records : record.zone])
-  dns_zone_id_map         = { for zone in local.declared_dns_zone_names : zone => data.hetznerdns_zone.exiting_dns_zones[zone].id }
+  dns_zone_id_map         = { for zone in local.declared_dns_zone_names : zone => data.hetznerdns_zone.existing_dns_zones[zone].id }
 }
 
-data "hetznerdns_zone" "exiting_dns_zones" {
+data "hetznerdns_zone" "existing_dns_zones" {
   for_each = local.declared_dns_zone_names
   name     = each.value
 }


### PR DESCRIPTION
Fix typos in variable names for `hetzner-dns` module